### PR TITLE
add blockReason to TransferLoyaltyCard

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -17933,8 +17933,14 @@ components:
           example: summer-loyalty-card-0543
           maxLength: 108
           type: string
+        blockReason:
+          description: |
+            Reason for transferring and blocking the loyalty card.
+          example: Card was lost
+          type: string
       required:
       - newCardIdentifier
+      - blockReason
       type: object
     UpdateLoyaltyCard:
       example:

--- a/model_transfer_loyalty_card.go
+++ b/model_transfer_loyalty_card.go
@@ -18,6 +18,23 @@ import (
 type TransferLoyaltyCard struct {
 	// The alphanumeric identifier of the loyalty card.
 	NewCardIdentifier string `json:"newCardIdentifier"`
+	// Reason for transferring and blocking the loyalty card.
+	BlockReason string `json:"blockReason"`
+}
+
+// GetBlockReason returns the BlockReason field value
+func (o *TransferLoyaltyCard) GetBlockReason() string {
+	if o == nil {
+		var ret string
+		return ret
+	}
+
+	return o.BlockReason
+}
+
+// SetNewCardIdentifier sets field value
+func (o *TransferLoyaltyCard) SetNewCardIdentifier(v string) {
+	o.NewCardIdentifier = v
 }
 
 // GetNewCardIdentifier returns the NewCardIdentifier field value
@@ -30,9 +47,9 @@ func (o *TransferLoyaltyCard) GetNewCardIdentifier() string {
 	return o.NewCardIdentifier
 }
 
-// SetNewCardIdentifier sets field value
-func (o *TransferLoyaltyCard) SetNewCardIdentifier(v string) {
-	o.NewCardIdentifier = v
+// SetBlockReason sets field value
+func (o *TransferLoyaltyCard) SetBlockReason(v string) {
+	o.BlockReason = v
 }
 
 type NullableTransferLoyaltyCard struct {


### PR DESCRIPTION
### Description
Adds a required blockReason to the TransferLoyaltyCard object.